### PR TITLE
Fix Mollie component init and cleanup duplicate functions

### DIFF
--- a/high-conversion-checkout-functions.php
+++ b/high-conversion-checkout-functions.php
@@ -335,79 +335,14 @@ function handle_ajax_checkout_processing() {
         wp_send_json_error(array('message' => 'Checkout processing failed: ' . $e->getMessage()));
     }
 }
-
-// Function to get order bump packages - FIXED: Single source of truth
 function get_order_bump_packages() {
-    $products = wc_get_products(array('limit' => 1, 'status' => 'publish'));
-    if (empty($products)) {
-        return array();
+    if (function_exists("get_checkout_order_bump_packages")) {
+        return get_checkout_order_bump_packages();
     }
-
-    $base_product = $products[0];
-
-    return array(
-        0 => array(
-            'product_id' => $base_product->get_id(),
-            'quantity' => 2,
-            'pills_total' => 8,
-            'title' => 'Viagra – Buy 2 Packs',
-            'discreet_title' => 'Viagra (2 Packs)',
-            'description' => '2 Packs (8 pills total) • Enhanced vitality support',
-            'price' => 3.95,
-            'original_price' => 4.98, // 2 × 2.49
-            'black_market_price' => 5.00,
-            'savings' => 1.03, // 4.98 - 3.95
-            'badge' => 'POPULAR',
-            'badge_color' => 'convert-orange',
-            'free_shipping' => false
-        ),
-        1 => array(
-            'product_id' => $base_product->get_id(),
-            'quantity' => 5,
-            'pills_total' => 20,
-            'title' => 'Viagra – Buy 5 Packs',
-            'discreet_title' => 'Viagra (5 Packs)',
-            'description' => '5 Packs (20 pills total) • Free shipping included',
-            'price' => 4.95,
-            'original_price' => 12.45, // 5 × 2.49
-            'black_market_price' => 13.00,
-            'savings' => 7.50, // 12.45 - 4.95
-            'badge' => 'BEST VALUE',
-            'badge_color' => 'medical-blue',
-            'free_shipping' => true
-        ),
-        2 => array(
-            'product_id' => $base_product->get_id(),
-            'quantity' => 10,
-            'pills_total' => 40,
-            'title' => 'Viagra – Buy 10 Packs',
-            'discreet_title' => 'Viagra (10 Packs)',
-            'description' => '10 Packs (40 pills total) • Free shipping + Free Guide',
-            'price' => 6.95,
-            'original_price' => 24.90, // 10 × 2.49
-            'black_market_price' => 25.00,
-            'savings' => 17.95, // 24.90 - 6.95
-            'badge' => 'MAX SAVINGS',
-            'badge_color' => 'purple-600',
-            'free_shipping' => true
-        ),
-        3 => array(
-            'product_id' => $base_product->get_id(),
-            'quantity' => 20,
-            'pills_total' => 80,
-            'title' => 'Viagra – Buy 20 Packs',
-            'discreet_title' => 'Viagra (20 Packs)',
-            'description' => '20 Packs (80 pills total) • Free shipping + Free Guide + VIP Support',
-            'price' => 9.95,
-            'original_price' => 49.80, // 20 × 2.49
-            'black_market_price' => 50.00,
-            'savings' => 39.85, // 49.80 - 9.95
-            'badge' => 'ULTIMATE DEAL',
-            'badge_color' => 'gradient-to-r from-purple-600 to-pink-600',
-            'free_shipping' => true
-        )
-    );
+    return array();
 }
+
+
 
 // Display package information in admin order details
 add_action('woocommerce_admin_order_data_after_billing_address', 'display_package_info_in_admin');

--- a/viagra-checkout.php
+++ b/viagra-checkout.php
@@ -2626,41 +2626,48 @@ echo $head;
 
         // Initialize Mollie Components
         function initializeMollieComponents() {
-            // Get Mollie profile ID from WordPress (you'll need to add this)
+            // Avoid creating components multiple times
+            if (mollieInstance && (mollieComponents.cardHolder || mollieComponents.mobileCardHolder)) {
+                console.log('Mollie Components already initialized');
+                return;
+            }
+
             const mollieProfileId = 'pfl_3RkSN1zuPE'; // Replace with your actual profile ID
-            
+
             try {
-                mollieInstance = Mollie(mollieProfileId, { 
-                    locale: 'en_US', 
-                    testmode: true // Set to false for production
-                });
+                if (!mollieInstance) {
+                    mollieInstance = Mollie(mollieProfileId, {
+                        locale: 'en_US',
+                        testmode: true // Set to false for production
+                    });
+                }
 
                 // Desktop components
-                if (document.getElementById('cardHolder')) {
+                if (document.getElementById('cardHolder') && !mollieComponents.cardHolder) {
                     mollieComponents.cardHolder = mollieInstance.createComponent('cardHolder');
                     mollieComponents.cardHolder.mount('#cardHolder .mollie-component--cardHolder');
-                    
+
                     mollieComponents.cardNumber = mollieInstance.createComponent('cardNumber');
                     mollieComponents.cardNumber.mount('#cardNumber .mollie-component--cardNumber');
-                    
+
                     mollieComponents.expiryDate = mollieInstance.createComponent('expiryDate');
                     mollieComponents.expiryDate.mount('#expiryDate .mollie-component--expiryDate');
-                    
+
                     mollieComponents.verificationCode = mollieInstance.createComponent('verificationCode');
                     mollieComponents.verificationCode.mount('#verificationCode .mollie-component--verificationCode');
                 }
 
                 // Mobile components
-                if (document.getElementById('mobile-cardHolder')) {
+                if (document.getElementById('mobile-cardHolder') && !mollieComponents.mobileCardHolder) {
                     mollieComponents.mobileCardHolder = mollieInstance.createComponent('cardHolder');
                     mollieComponents.mobileCardHolder.mount('#mobile-cardHolder .mollie-component--cardHolder');
-                    
+
                     mollieComponents.mobileCardNumber = mollieInstance.createComponent('cardNumber');
                     mollieComponents.mobileCardNumber.mount('#mobile-cardNumber .mollie-component--cardNumber');
-                    
+
                     mollieComponents.mobileExpiryDate = mollieInstance.createComponent('expiryDate');
                     mollieComponents.mobileExpiryDate.mount('#mobile-expiryDate .mollie-component--expiryDate');
-                    
+
                     mollieComponents.mobileVerificationCode = mollieInstance.createComponent('verificationCode');
                     mollieComponents.mobileVerificationCode.mount('#mobile-verificationCode .mollie-component--verificationCode');
                 }


### PR DESCRIPTION
## Summary
- remove duplicate order bump package data from `high-conversion-checkout-functions.php`
- delegate order bump package retrieval to checkout template
- guard Mollie component initialization against multiple executions

## Testing
- `php -l high-conversion-checkout-functions.php`
- `php -l viagra-checkout.php`

------
https://chatgpt.com/codex/tasks/task_e_6887f1cabf58832f94a54ec70d6565be